### PR TITLE
Update to incremental invoice sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Petit projet Go pour se connecter à PostgreSQL et exécuter périodiquement une
 - `DB_NAME`
 - `SYNC_INTERVAL` (optionnel, en secondes, valeur par défaut : `10`)
 
+Le programme mémorise l'identifiant de la dernière facture synchronisée dans
+le fichier `sync_state.json` afin de n'importer que les nouvelles factures.
+
 Créez éventuellement un fichier `.env` pour définir ces variables lors du développement.
 
 ## Lancement

--- a/config/env.go
+++ b/config/env.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"github.com/joho/godotenv"
 	"log"
 	"os"
@@ -26,32 +25,4 @@ func SyncInterval() time.Duration {
 		log.Printf("intervalle invalide %q, utilisation de la valeur par défaut", v)
 	}
 	return 10 * time.Second
-}
-
-// StartDate lit la date de début dans la variable START_DATE.
-// Le format attendu est YYYY-MM-DD.
-func StartDate() (time.Time, error) {
-	v := os.Getenv("START_DATE")
-	if v == "" {
-		return time.Time{}, fmt.Errorf("START_DATE non definie")
-	}
-	t, err := time.Parse("2006-01-02", v)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("START_DATE invalide: %w", err)
-	}
-	return t, nil
-}
-
-// EndDate lit la date de fin dans la variable END_DATE.
-// Le format attendu est YYYY-MM-DD.
-func EndDate() (time.Time, error) {
-	v := os.Getenv("END_DATE")
-	if v == "" {
-		return time.Time{}, fmt.Errorf("END_DATE non definie")
-	}
-	t, err := time.Parse("2006-01-02", v)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("END_DATE invalide: %w", err)
-	}
-	return t, nil
 }

--- a/config/state.go
+++ b/config/state.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+)
+
+const stateFile = "sync_state.json"
+
+type syncState struct {
+	LastID int `json:"last_id"`
+}
+
+// LoadLastID lit l'identifiant de la derniere facture traitee depuis le fichier de statut.
+func LoadLastID() int {
+	b, err := os.ReadFile(stateFile)
+	if err != nil {
+		return 0
+	}
+	var s syncState
+	if err := json.Unmarshal(b, &s); err != nil {
+		return 0
+	}
+	return s.LastID
+}
+
+// SaveLastID enregistre l'identifiant de la derniere facture traitee.
+func SaveLastID(id int) error {
+	s := syncState{LastID: id}
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(stateFile, b, 0644)
+}

--- a/db/invoices.go
+++ b/db/invoices.go
@@ -62,3 +62,57 @@ func FetchInvoicesBetween(ctx context.Context, conn *pgx.Conn, start, end time.T
 	}
 	return invoices, nil
 }
+
+// FetchInvoicesAfterID retourne toutes les factures avec un identifiant superieur a lastID.
+func FetchInvoicesAfterID(ctx context.Context, conn *pgx.Conn, lastID int) ([]models.Invoice, error) {
+	const query = `
+        SELECT id, invoice_type, payment_method, template, is_rne, rne,
+               client_ncc, client_company_name, client_phone, client_email,
+               client_seller_name, point_of_sale, establishment,
+               commercial_message, footer, foreign_currency,
+               foreign_currency_rate, taxes, custom_taxes, items
+        FROM invoices
+        WHERE id > $1
+        ORDER BY id ASC
+    `
+
+	rows, err := conn.Query(ctx, query, lastID)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	var invoices []models.Invoice
+	for rows.Next() {
+		var inv models.Invoice
+		if err := rows.Scan(
+			&inv.ID,
+			&inv.InvoiceType,
+			&inv.PaymentMethod,
+			&inv.Template,
+			&inv.IsRne,
+			&inv.Rne,
+			&inv.ClientNcc,
+			&inv.ClientCompanyName,
+			&inv.ClientPhone,
+			&inv.ClientEmail,
+			&inv.ClientSellerName,
+			&inv.PointOfSale,
+			&inv.Establishment,
+			&inv.CommercialMessage,
+			&inv.Footer,
+			&inv.ForeignCurrency,
+			&inv.ForeignCurrencyRate,
+			&inv.Taxes,
+			&inv.CustomTaxes,
+			&inv.Items,
+		); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		invoices = append(invoices, inv)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return invoices, nil
+}


### PR DESCRIPTION
## Summary
- track last synced invoice in `sync_state.json`
- remove start and end date config logic
- add function to fetch invoices after the last ID
- persist sync progress between runs

## Testing
- `go build ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e15e4a504832c978f269f209b95fa