### PR TITLE
Integrate FNE certification flow

### DIFF
--- a/config/metadata.go
+++ b/config/metadata.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+)
+
+const metadataFile = "invoice_metadata.json"
+
+type InvoiceMetadata struct {
+	InvoiceID int    `json:"invoice_id"`
+	Reference string `json:"reference"`
+	Token     string `json:"token"`
+}
+
+// AppendMetadata ajoute des métadonnées à l'historique local.
+func AppendMetadata(meta InvoiceMetadata) error {
+	var list []InvoiceMetadata
+	if b, err := os.ReadFile(metadataFile); err == nil {
+		json.Unmarshal(b, &list)
+	}
+	list = append(list, meta)
+	data, err := json.Marshal(list)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(metadataFile, data, 0644)
+}

--- a/services/converter.go
+++ b/services/converter.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"pythagoreSynchroniser/models"
+	"strconv"
+)
+
+// ConvertInvoice convertit une facture de la base en requête FNE.
+func ConvertInvoice(inv models.Invoice) (models.FNEInvoiceRequest, error) {
+	var req models.FNEInvoiceRequest
+
+	req.InvoiceType = inv.InvoiceType
+	req.PaymentMethod = inv.PaymentMethod
+	req.Template = inv.Template
+	req.IsRne = inv.IsRne
+	req.Rne = inv.Rne
+	req.ClientNcc = inv.ClientNcc
+	req.ClientCompanyName = inv.ClientCompanyName
+	req.ClientPhone = strconv.FormatInt(inv.ClientPhone, 10)
+	req.ClientEmail = inv.ClientEmail
+	req.ClientSellerName = inv.ClientSellerName
+	req.PointOfSale = inv.PointOfSale
+	req.Establishment = inv.Establishment
+	req.CommercialMessage = inv.CommercialMessage
+	req.Footer = inv.Footer
+	if inv.ForeignCurrency != nil {
+		req.ForeignCurrency = *inv.ForeignCurrency
+	}
+	if inv.ForeignCurrencyRate != nil {
+		req.ForeignCurrencyRate = *inv.ForeignCurrencyRate
+	}
+	req.Taxes = inv.Taxes
+
+	if inv.CustomTaxes != nil {
+		var ct []models.CustomTax
+		if err := json.Unmarshal([]byte(*inv.CustomTaxes), &ct); err == nil {
+			req.CustomTaxes = ct
+		}
+	}
+
+	if err := json.Unmarshal([]byte(inv.Items), &req.Items); err != nil {
+		return req, fmt.Errorf("parse items: %w", err)
+	}
+
+	return req, nil
+}

--- a/services/fne.go
+++ b/services/fne.go
@@ -10,27 +10,28 @@ import (
 	"pythagoreSynchroniser/models"
 )
 
-func sendInvoiceToFNE(invoice models.FNEInvoiceRequest, token string) error {
+// SendInvoiceToFNE envoie une facture à l'API FNE et renvoie les métadonnées obtenues.
+func SendInvoiceToFNE(invoice models.FNEInvoiceRequest, token string) (string, string, error) {
 	url := os.Getenv("FNE_API_URL")
 	if url == "" {
-		return fmt.Errorf("FNE_API_URL n'est pas défini")
+		return "", "", fmt.Errorf("FNE_API_URL n'est pas défini")
 	}
 
 	if token == "" {
 		token = os.Getenv("FNE_API_TOKEN")
 		if token == "" {
-			return fmt.Errorf("FNE_API_TOKEN manquant")
+			return "", "", fmt.Errorf("FNE_API_TOKEN manquant")
 		}
 	}
 
 	body, err := json.Marshal(invoice)
 	if err != nil {
-		return fmt.Errorf("JSON marshal failed: %w", err)
+		return "", "", fmt.Errorf("JSON marshal failed: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return "", "", fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -39,13 +40,13 @@ func sendInvoiceToFNE(invoice models.FNEInvoiceRequest, token string) error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return "", "", fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API error: %s", string(respBody))
+		return "", "", fmt.Errorf("API error: %s", string(respBody))
 	}
 
 	var response struct {
@@ -53,9 +54,9 @@ func sendInvoiceToFNE(invoice models.FNEInvoiceRequest, token string) error {
 		Token     string `json:"token"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
+		return "", "", fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	fmt.Printf("Facture certifiée : ref=%s, QR token=%s\n", response.Reference, response.Token)
-	return nil
+	return response.Reference, response.Token, nil
 }


### PR DESCRIPTION
## Summary
- convert invoices to the FNE format
- send invoices to the FNE API and capture the response
- store returned metadata locally

## Testing
- `go vet ./...` *(fails: proxy.golang.org access blocked)*