### PR TITLE
Add Go unit tests for config and service packages

### DIFF
--- a/config/env_test.go
+++ b/config/env_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSyncIntervalDefault(t *testing.T) {
+	t.Setenv("SYNC_INTERVAL", "")
+	if d := SyncInterval(); d != 10*time.Second {
+		t.Fatalf("expected 10s, got %v", d)
+	}
+}
+
+func TestSyncIntervalValid(t *testing.T) {
+	t.Setenv("SYNC_INTERVAL", "5")
+	if d := SyncInterval(); d != 5*time.Second {
+		t.Fatalf("expected 5s, got %v", d)
+	}
+}
+
+func TestSyncIntervalInvalid(t *testing.T) {
+	t.Setenv("SYNC_INTERVAL", "abc")
+	if d := SyncInterval(); d != 10*time.Second {
+		t.Fatalf("expected default 10s, got %v", d)
+	}
+}

--- a/config/metadata_test.go
+++ b/config/metadata_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestAppendMetadata(t *testing.T) {
+	dir := t.TempDir()
+	wd, _ := os.Getwd()
+	defer os.Chdir(wd)
+	os.Chdir(dir)
+
+	m1 := InvoiceMetadata{InvoiceID: 1, Reference: "r1", Token: "t1"}
+	if err := AppendMetadata(m1); err != nil {
+		t.Fatalf("append1: %v", err)
+	}
+	m2 := InvoiceMetadata{InvoiceID: 2, Reference: "r2", Token: "t2"}
+	if err := AppendMetadata(m2); err != nil {
+		t.Fatalf("append2: %v", err)
+	}
+
+	data, err := os.ReadFile(metadataFile)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var list []InvoiceMetadata
+	if err := json.Unmarshal(data, &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list) != 2 || list[0] != m1 || list[1] != m2 {
+		t.Fatalf("unexpected list: %+v", list)
+	}
+}

--- a/config/state_test.go
+++ b/config/state_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadLastIDNoFile(t *testing.T) {
+	dir := t.TempDir()
+	wd, _ := os.Getwd()
+	defer os.Chdir(wd)
+	os.Chdir(dir)
+	if id := LoadLastID(); id != 0 {
+		t.Fatalf("expected 0, got %d", id)
+	}
+}
+
+func TestSaveAndLoadLastID(t *testing.T) {
+	dir := t.TempDir()
+	wd, _ := os.Getwd()
+	defer os.Chdir(wd)
+	os.Chdir(dir)
+
+	if err := SaveLastID(42); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if id := LoadLastID(); id != 42 {
+		t.Fatalf("expected 42, got %d", id)
+	}
+}

--- a/services/converter_test.go
+++ b/services/converter_test.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"pythagoreSynchroniser/models"
+	"testing"
+)
+
+func TestConvertInvoice(t *testing.T) {
+	itemsJSON := `[{"reference":"ref1","description":"desc","quantity":1,"amount":10,"taxes":["A"]}]`
+	customTaxes := `[{"name":"tva","amount":1}]`
+	rate := 2.5
+	foreign := "USD"
+	seller := "seller"
+	inv := models.Invoice{
+		ID:                  1,
+		InvoiceType:         "sale",
+		PaymentMethod:       "cash",
+		Template:            "default",
+		IsRne:               true,
+		Rne:                 nil,
+		ClientNcc:           nil,
+		ClientCompanyName:   "ACME",
+		ClientPhone:         12345,
+		ClientEmail:         "a@b.com",
+		ClientSellerName:    &seller,
+		PointOfSale:         "pos",
+		Establishment:       "est",
+		CommercialMessage:   nil,
+		Footer:              nil,
+		ForeignCurrency:     &foreign,
+		ForeignCurrencyRate: &rate,
+		Taxes:               "VAT",
+		CustomTaxes:         &customTaxes,
+		Items:               itemsJSON,
+	}
+
+	req, err := ConvertInvoice(inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.InvoiceType != inv.InvoiceType || req.PaymentMethod != inv.PaymentMethod || len(req.Items) != 1 {
+		t.Fatalf("unexpected request: %+v", req)
+	}
+	if req.ForeignCurrency != foreign || req.ForeignCurrencyRate != rate {
+		t.Fatalf("currency not copied")
+	}
+	if len(req.CustomTaxes) != 1 || req.CustomTaxes[0].Name != "tva" {
+		t.Fatalf("custom taxes not parsed")
+	}
+}
+
+func TestConvertInvoiceBadItems(t *testing.T) {
+	inv := models.Invoice{Items: "not-json"}
+	if _, err := ConvertInvoice(inv); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/services/fne_test.go
+++ b/services/fne_test.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"pythagoreSynchroniser/models"
+	"testing"
+)
+
+func TestSendInvoiceToFNE_NoURL(t *testing.T) {
+	t.Setenv("FNE_API_URL", "")
+	_, _, err := SendInvoiceToFNE(models.FNEInvoiceRequest{}, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSendInvoiceToFNE_NoToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	t.Setenv("FNE_API_URL", srv.URL)
+	t.Setenv("FNE_API_TOKEN", "")
+	_, _, err := SendInvoiceToFNE(models.FNEInvoiceRequest{}, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSendInvoiceToFNE_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad request"))
+	}))
+	defer srv.Close()
+	t.Setenv("FNE_API_URL", srv.URL)
+	t.Setenv("FNE_API_TOKEN", "tok")
+	_, _, err := SendInvoiceToFNE(models.FNEInvoiceRequest{}, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSendInvoiceToFNE_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req models.FNEInvoiceRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"reference": "ref", "token": "tok"})
+	}))
+	defer srv.Close()
+	t.Setenv("FNE_API_URL", srv.URL)
+	t.Setenv("FNE_API_TOKEN", "tok")
+	ref, tok, err := SendInvoiceToFNE(models.FNEInvoiceRequest{InvoiceType: "A"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "ref" || tok != "tok" {
+		t.Fatalf("unexpected response %s %s", ref, tok)
+	}
+}


### PR DESCRIPTION
## Summary
- add test coverage for config/env.go
- add tests for saving sync state and metadata history
- test invoice conversion logic
- test FNE API client behaviour

## Testing
- `go test ./...` *(fails: forbidden downloading modules)*
