### PR TITLE
Fix dashboard error on corrupted metadata

### DIFF
--- a/config/metadata.go
+++ b/config/metadata.go
@@ -1,10 +1,12 @@
 package config
 
 import (
-        "encoding/json"
-        "fmt"
-        "os"
-        "path/filepath"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"pythagoreSynchroniser/logging"
 )
 
 const metadataDir = "data/metadata"
@@ -17,40 +19,41 @@ type InvoiceMetadata struct {
 
 // LoadMetadata retourne toutes les métadonnées enregistrées.
 func LoadMetadata() ([]InvoiceMetadata, error) {
-        entries, err := os.ReadDir(metadataDir)
-        if err != nil {
-                if os.IsNotExist(err) {
-                        return nil, nil
-                }
-                return nil, err
-        }
-        var list []InvoiceMetadata
-        for _, e := range entries {
-                if e.IsDir() {
-                        continue
-                }
-                data, err := os.ReadFile(filepath.Join(metadataDir, e.Name()))
-                if err != nil {
-                        return nil, err
-                }
-                var m InvoiceMetadata
-                if err := json.Unmarshal(data, &m); err != nil {
-                        return nil, err
-                }
-                list = append(list, m)
-        }
-        return list, nil
+	entries, err := os.ReadDir(metadataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var list []InvoiceMetadata
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(metadataDir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var m InvoiceMetadata
+		if err := json.Unmarshal(data, &m); err != nil {
+			logging.Warnf("fichier metadata %s invalide: %v", e.Name(), err)
+			continue
+		}
+		list = append(list, m)
+	}
+	return list, nil
 }
 
 // AppendMetadata ajoute des métadonnées à l'historique local.
 func AppendMetadata(meta InvoiceMetadata) error {
-        if err := os.MkdirAll(metadataDir, 0755); err != nil {
-                return err
-        }
-        b, err := json.Marshal(meta)
-        if err != nil {
-                return err
-        }
-        path := filepath.Join(metadataDir, fmt.Sprintf("%d.json", meta.InvoiceID))
-        return os.WriteFile(path, b, 0644)
+	if err := os.MkdirAll(metadataDir, 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(metadataDir, fmt.Sprintf("%d.json", meta.InvoiceID))
+	return os.WriteFile(path, b, 0644)
 }

--- a/config/metadata_test.go
+++ b/config/metadata_test.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-        "os"
-        "testing"
+	"os"
+	"testing"
 )
 
 func TestAppendMetadata(t *testing.T) {
@@ -19,20 +19,41 @@ func TestAppendMetadata(t *testing.T) {
 		return
 	}
 
-        m1 := InvoiceMetadata{InvoiceID: 1, Reference: "r1", Token: "t1"}
-        if err := AppendMetadata(m1); err != nil {
-                t.Fatalf("append1: %v", err)
-        }
-        m2 := InvoiceMetadata{InvoiceID: 2, Reference: "r2", Token: "t2"}
-        if err := AppendMetadata(m2); err != nil {
-                t.Fatalf("append2: %v", err)
-        }
+	m1 := InvoiceMetadata{InvoiceID: 1, Reference: "r1", Token: "t1"}
+	if err := AppendMetadata(m1); err != nil {
+		t.Fatalf("append1: %v", err)
+	}
+	m2 := InvoiceMetadata{InvoiceID: 2, Reference: "r2", Token: "t2"}
+	if err := AppendMetadata(m2); err != nil {
+		t.Fatalf("append2: %v", err)
+	}
 
-        list, err := LoadMetadata()
-        if err != nil {
-                t.Fatalf("load: %v", err)
-        }
-        if len(list) != 2 || list[0] != m1 || list[1] != m2 {
-                t.Fatalf("unexpected list: %+v", list)
-        }
+	list, err := LoadMetadata()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(list) != 2 || list[0] != m1 || list[1] != m2 {
+		t.Fatalf("unexpected list: %+v", list)
+	}
+}
+
+func TestLoadMetadataInvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	wd, _ := os.Getwd()
+	defer os.Chdir(wd)
+	os.Chdir(dir)
+
+	os.MkdirAll("data/metadata", 0755)
+	err := os.WriteFile("data/metadata/bad.json", []byte("{"), 0644)
+	if err != nil {
+		t.Fatalf("write bad file: %v", err)
+	}
+
+	list, err := LoadMetadata()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %d", len(list))
+	}
 }


### PR DESCRIPTION
## Summary
- skip invalid JSON files when loading invoice metadata
- log a warning and continue collecting metadata
- test that `LoadMetadata` ignores malformed entries

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org": Forbidden)*