### PR TITLE
Improve metrics logging and metadata handling

### DIFF
--- a/config/metadata.go
+++ b/config/metadata.go
@@ -28,7 +28,7 @@ func LoadMetadata() ([]InvoiceMetadata, error) {
 	}
 	var list []InvoiceMetadata
 	for _, e := range entries {
-		if e.IsDir() {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(metadataDir, e.Name()))

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,9 +1,12 @@
 package logging
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strings"
+	"sync"
+	"time"
 )
 
 type Level int
@@ -15,8 +18,37 @@ const (
 	ERROR
 )
 
+func (l Level) String() string {
+	switch l {
+	case DEBUG:
+		return "DEBUG"
+	case INFO:
+		return "INFO"
+	case WARN:
+		return "WARN"
+	case ERROR:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 var current = INFO
 var l = log.New(os.Stdout, "", log.LstdFlags)
+
+// Entry represente une entree de journal.
+type Entry struct {
+	Time    time.Time
+	Level   Level
+	Message string
+}
+
+var (
+	mu      sync.Mutex
+	entries []Entry
+	// maxEntries limite la taille du buffer de logs conserve en memoire.
+	maxEntries = 1000
+)
 
 // Setup initialise le niveau de journalisation depuis la variable LOG_LEVEL.
 func Setup() {
@@ -32,30 +64,91 @@ func Setup() {
 	}
 }
 
+func levelString(lv Level) string {
+	switch lv {
+	case DEBUG:
+		return "DEBUG"
+	case INFO:
+		return "INFO"
+	case WARN:
+		return "WARN"
+	case ERROR:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func addEntry(lv Level, msg string) {
+	mu.Lock()
+	defer mu.Unlock()
+	entries = append(entries, Entry{Time: time.Now(), Level: lv, Message: msg})
+	if len(entries) > maxEntries {
+		entries = entries[len(entries)-maxEntries:]
+	}
+}
+
 func Debugf(format string, args ...interface{}) {
 	if current <= DEBUG {
-		l.Printf("DEBUG "+format, args...)
+		msg := fmt.Sprintf(format, args...)
+		l.Printf("DEBUG %s", msg)
+		addEntry(DEBUG, msg)
 	}
 }
 
 func Infof(format string, args ...interface{}) {
 	if current <= INFO {
-		l.Printf("INFO "+format, args...)
+		msg := fmt.Sprintf(format, args...)
+		l.Printf("INFO %s", msg)
+		addEntry(INFO, msg)
 	}
 }
 
 func Warnf(format string, args ...interface{}) {
 	if current <= WARN {
-		l.Printf("WARN "+format, args...)
+		msg := fmt.Sprintf(format, args...)
+		l.Printf("WARN %s", msg)
+		addEntry(WARN, msg)
 	}
 }
 
 func Errorf(format string, args ...interface{}) {
 	if current <= ERROR {
-		l.Printf("ERROR "+format, args...)
+		msg := fmt.Sprintf(format, args...)
+		l.Printf("ERROR %s", msg)
+		addEntry(ERROR, msg)
 	}
 }
 
 func Fatalln(args ...interface{}) {
 	l.Fatalln(args...)
+}
+
+// Entries renvoie la liste des entrees de journal avec un niveau minimum.
+func Entries(min Level) []Entry {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		if e.Level >= min {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// LevelFromString convertit une chaine en niveau de log.
+func LevelFromString(s string) Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return DEBUG
+	case "info":
+		return INFO
+	case "warn":
+		return WARN
+	case "error":
+		return ERROR
+	default:
+		return DEBUG
+	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"net/http"
 	"pythagoreSynchroniser/config"
+	"pythagoreSynchroniser/logging"
 	"runtime"
 	"time"
 )
@@ -31,6 +32,7 @@ type DashboardMetrics struct {
 	Goroutines       int
 	MemoryAlloc      uint64
 	NumGC            uint32
+	Logs             []logging.Entry
 }
 
 // CollectFneMetrics calcule les statistiques d'envoi FNE.
@@ -136,6 +138,10 @@ func DashboardHandler(db *sql.DB) http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		lvl := logging.LevelFromString(r.URL.Query().Get("level"))
+		m.Logs = logging.Entries(lvl)
+
 		if err := dashboardTmpl.Execute(w, m); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -91,6 +91,20 @@
                 {{range $k, $v := .ByPointOfSale}}<tr><td>{{$k}}</td><td>{{$v}}</td></tr>{{end}}
                 </tbody>
             </table>
+
+            <h3 class="mt-5">Journalisation</h3>
+            <form class="mb-3" method="get">
+                <label for="level" class="form-label">Niveau minimum</label>
+                <select name="level" id="level" class="form-select" onchange="this.form.submit()">
+                    <option value="debug">DEBUG</option>
+                    <option value="info">INFO</option>
+                    <option value="warn">WARN</option>
+                    <option value="error">ERROR</option>
+                </select>
+            </form>
+           <pre class="bg-dark text-light p-3" style="max-height: 400px; overflow-y: auto;">
+{{range .Logs}}{{.Time}} [{{.Level}}] {{.Message}}
+{{end}}</pre>
         </div>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- skip non-JSON files when loading metadata
- keep an in-memory log buffer and expose logs via metrics HTTP page
- allow filtering logs by level using query parameter
- display logs in metrics dashboard page

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e301080d4832c9cc9b7f84bcc40ae